### PR TITLE
更正README中一处拼写笔误

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ DDD脚手架
 │                           │   ├── ServiceException.java
 │                           │   └── ValidationException.java
 │                           ├── result // 返回结果集
-│                           │   ├── BaseResult.javar
+│                           │   ├── BaseResult.java
 │                           │   ├── Page.java
 │                           │   ├── PageResult.java
 │                           │   └── Result.java


### PR DESCRIPTION
```
│                           ├── result // 返回结果集
│                           │   ├── BaseResult.javar
```
多打了一个字母r